### PR TITLE
Replace to_code by compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ from uneval import quote as q
 
 ### Converters ###
 
-| Converter      | Target      | Remark                     |
-|----------------|-------------|----------------------------|
-| `str`          | String      | Convert to readable python |
-| `to_ast`       | AST-node    | Convert to AST-node        |
-| `to_code`      | Code-object | Compile the expression     |
-| `F.parameters` | Function    | Create a λ-function        |
+| Converter                    | Target      | Remark                     |
+|------------------------------|-------------|----------------------------|
+| `str`                        | String      | Convert to readable python |
+| `to_ast`                     | AST-node    | Convert to AST-node        |
+| `compile` (alias `compile_`) | Code-object | Compile the expression     |
+| `F.parameters`               | Function    | Create a λ-function        |
 
 ## Similar work ##
 

--- a/uneval/__init__.py
+++ b/uneval/__init__.py
@@ -1,11 +1,12 @@
 from .builders import and_, or_, not_, in_, quote, if_, for_, lambda_, λ_, fstr, fmt
-from .convert_code import to_code, to_ast
+from .convert_code import compile, compile_, to_ast
 from .convert_lambda import F, λ
 from .expression import Expression
 
 __all__ = [
     "Expression",
-    "to_code",
+    "compile",
+    "compile_",
     "to_ast",
     "F",
     "λ",

--- a/uneval/convert_code.py
+++ b/uneval/convert_code.py
@@ -1,16 +1,9 @@
 import ast
-from functools import singledispatch
 from collections.abc import Hashable
-from types import CodeType
+from functools import singledispatch
 
-
-def to_code(node) -> CodeType:
-    """Compile str, expression or ast as expression."""
-    node = to_ast(node)
-    if not isinstance(node, ast.mod):
-        node = ast.Expression(node)
-    ast.fix_missing_locations(node)
-    return compile(node, "<uneval.Expression>", mode='eval')
+# Make built-in compile extensible
+compile = compile_ = singledispatch(compile)
 
 
 # Use of singledispatch is just an implementation detail (don't register other)

--- a/uneval/convert_lambda.py
+++ b/uneval/convert_lambda.py
@@ -1,6 +1,6 @@
 import inspect
 
-from .convert_code import to_ast, to_code
+from .convert_code import to_ast, compile
 from .builders import quote, λ_
 
 
@@ -24,7 +24,7 @@ class _FunctionFactory:
         else:
             locals, globals = {}, {}
 
-        return eval(to_code(λ_((), to_ast(body))), globals, locals)
+        return eval(compile(λ_((), to_ast(body))), globals, locals)
 
     def __getattr__(self, item):
         """Create a lambda with single-letter parameters.
@@ -48,7 +48,7 @@ class _FunctionFactory:
 
         def accept_body(body):
             """Call with an expression to register as a body."""
-            return eval(to_code(λ_(parameters, to_ast(body))), globals, locals)
+            return eval(compile(λ_(parameters, to_ast(body))), globals, locals)
 
         return accept_body
 


### PR DESCRIPTION
Pros:
- `compile` becomes the single function to compile `str`, `ast` and `Expression` (simplification)
- Currently, `to_code("print(x)")` compiles to `"print(x)"` (literally). This might be unexpected.
- It only takes effect when imported and `compile_` can be provided as an alias.

Cons:
- It requires a change (but this project is still young)
- Overwriting built-in names is generally considered bad-practice (although it's an extension, nothing is lost)
- It's not really orthogonal in case others extend `compile` as well using a different method
- Once `compile` is extended, it might become tempting to also extend `eval` or other functions.
